### PR TITLE
Update GitHub username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ LABEL "com.github.actions.icon"="arrow-up-right"
 LABEL "com.github.actions.color"="gray-dark"
 
 LABEL version="1.0.4"
-LABEL repository="http://github.com/pullreminders/assignee-to-reviewer-action"
-LABEL homepage="http://github.com/pullreminders/assignee-to-reviewer-action"
+LABEL repository="http://github.com/abinoda/assignee-to-reviewer-action"
+LABEL homepage="http://github.com/abinoda/assignee-to-reviewer-action"
 LABEL maintainer="Abi Noda <abi@pullreminders.com>"
 
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assignee to Reviewer
-        uses: pullreminders/assignee-to-reviewer-action@v1.0.4
+        uses: abinoda/assignee-to-reviewer-action@v1.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -27,7 +27,7 @@ Note that the workflow for `pull_request` events will be triggered by default on
 
 ## Demo
 
-<img src="https://github.com/pullreminders/assignee-to-reviewer-action/raw/master/docs/images/example.png" width="540">
+<img src="https://github.com/abinoda/assignee-to-reviewer-action/raw/master/docs/images/example.png" width="540">
 
 ## License
 


### PR DESCRIPTION
It seems the repository was transferred from `pullreminders` to `abinoda`, so I will update GitHub URLs and installation guide in this PR.

![Screen Shot 2022-01-20 at 8 41 13 PM](https://user-images.githubusercontent.com/10768439/150332217-90391307-4bcd-4c15-81bf-0caae553178a.png)

